### PR TITLE
fix: use correct metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "environment-variable-policy"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "environment-variable-policy"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["José Guilherme Vanz <jvanz@jvanz.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,14 +1,14 @@
 ---
-version: 0.1.2
+version: 0.1.3
 name: environment-variable-policy
 displayName: Environment Variable Policy
-createdAt: '2023-01-19T14:46:21+02:00'
+createdAt: '2023-02-06T14:46:21+02:00'
 description: A Kubewarden Policy that controls the usage of environment variables
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/environment-variable-policy
 containersImages:
 - name: policy
-  image: "ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.2"
+  image: "ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.3"
 keywords:
 - deployment
 - replicaset
@@ -22,7 +22,7 @@ keywords:
 - environment-variables
 links:
 - name: policy
-  url: https://github.com/kubewarden/environment-variable-policy/releases/download/v0.1.2/policy.wasm
+  url: https://github.com/kubewarden/environment-variable-policy/releases/download/v0.1.3/policy.wasm
 - name: source
   url: https://github.com/kubewarden/environment-variable-policy
 provider:
@@ -37,8 +37,20 @@ annotations:
     rules:
     - apiGroups: [""]
       apiVersions: ["v1"]
-      resources: ["deployment","replicaset","statefulset","daemonset","replicationcontroller","job","cronjob","pod"]
-      operations: ["CREATE"]
+      resources: ["pods"]
+      operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["replicationcontrollers"]
+      operations: ["CREATE", "UPDATE"]
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments","replicasets","statefulsets","daemonsets"]
+      operations: ["CREATE", "UPDATE"]
+    - apiGroups: ["batch"]
+      apiVersions: ["v1"]
+      resources: ["jobs","cronjobs"]
+      operations: ["CREATE", "UPDATE"]
   kubewarden/questions-ui: |
     questions:
     - default: null

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,8 +1,20 @@
 rules:
-- apiGroups: [""]
-  apiVersions: ["v1"]
-  resources: ["deployment","replicaset","statefulset","daemonset","replicationcontroller","job","cronjob","pod"]
-  operations: ["CREATE"]
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["replicationcontrollers"]
+    operations: ["CREATE", "UPDATE"]
+  - apiGroups: ["apps"]
+    apiVersions: ["v1"]
+    resources: ["deployments","replicasets","statefulsets","daemonsets"]
+    operations: ["CREATE", "UPDATE"]
+  - apiGroups: ["batch"]
+    apiVersions: ["v1"]
+    resources: ["jobs","cronjobs"]
+    operations: ["CREATE", "UPDATE"]
 mutating: false
 contextAware: false
 executionMode: kubewarden-wapc


### PR DESCRIPTION
Tag a new relase of the policy that has the right metadata inside of its
`rules` section.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>
