### PR TITLE
Bump v0.1.6 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "environment-variable-policy"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "environment-variable-policy"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["José Guilherme Vanz <jvanz@jvanz.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.5
+version: 0.1.6
 name: environment-variable-policy
 displayName: Environment Variable Policy
-createdAt: 2023-03-21T12:15:35.576788965Z
+createdAt: 2023-07-07T19:16:31.932345772Z
 description: A Kubewarden Policy that controls the usage of environment variables
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/environment-variable-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.5
+  image: ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.6
 keywords:
 - deployment
 - replicaset
@@ -27,13 +27,13 @@ keywords:
 - environment-variables
 links:
 - name: policy
-  url: https://github.com/kubewarden/environment-variable-policy/releases/download/v0.1.5/policy.wasm
+  url: https://github.com/kubewarden/environment-variable-policy/releases/download/v0.1.6/policy.wasm
 - name: source
   url: https://github.com/kubewarden/environment-variable-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.5
+  kwctl pull ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.6
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.6 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.6

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
