### PR TITLE
fix: validate when envvar value is missing.

### DIFF
--- a/e2e.bats
+++ b/e2e.bats
@@ -7,8 +7,22 @@
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
  }
 
+@test "Test anyIn with name only" {
+	run kwctl run  --request-path test_data/deployment_anyin.json --settings-path test_data/settings_anyin_names_only.json  annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+ }
+
 @test "Test anyNotIn" {
 	run kwctl run  --request-path test_data/deployment_anynotin.json --settings-path test_data/settings_anynotin.json  annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+ }
+
+@test "Test anyNotIn with names only" {
+	run kwctl run  --request-path test_data/deployment_anynotin.json --settings-path test_data/settings_anynotin_names_only.json  annotated-policy.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
@@ -21,9 +35,24 @@
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
  }
 
+@test "Test allAreUsed with names only" {
+	run kwctl run  --request-path test_data/deployment_allareused.json --settings-path test_data/settings_allareused_names_only.json  annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+ }
+
 @test "Test notAllAreUsed" {
 	run kwctl run  --request-path test_data/deployment_notallareused.json --settings-path test_data/settings_notallareused.json  annotated-policy.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
  }
+
+@test "Test notAllAreUsed with names only" {
+	run kwctl run  --request-path test_data/deployment_notallareused.json --settings-path test_data/settings_notallareused_names_only.json  annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+ }
+

--- a/test_data/settings_allareused_names_only.json
+++ b/test_data/settings_allareused_names_only.json
@@ -1,0 +1,13 @@
+"rules": [
+	{
+		"reject": "allAreUsed",
+		"environmentVariables": [
+			{
+				"name": "foo"
+			},
+			{
+				"name": "foo2"
+			}
+		]
+	}
+]

--- a/test_data/settings_anyin_names_only.json
+++ b/test_data/settings_anyin_names_only.json
@@ -1,0 +1,10 @@
+"rules": [
+	{
+		"reject": "anyIn",
+		"environmentVariables": [
+			{
+				"name": "envvar"
+			}
+		]
+	}
+]

--- a/test_data/settings_anynotin_names_only.json
+++ b/test_data/settings_anynotin_names_only.json
@@ -1,0 +1,10 @@
+"rules": [
+	{
+		"reject": "anyNotIn",
+		"environmentVariables": [
+			{
+				"name": "envvar"
+			}
+		]
+	}
+]

--- a/test_data/settings_notallareused_names_only.json
+++ b/test_data/settings_notallareused_names_only.json
@@ -1,0 +1,13 @@
+"rules": [
+	{
+		"reject": "notAllAreUsed",
+		"environmentVariables": [
+			{
+				"name": "foo"
+			},
+			{
+				"name": "foo2"
+			}
+		]
+	}
+]


### PR DESCRIPTION
## Description

Updates the validation code to ensure that when the user does not define the envvar value is defined in the rule, the policy will validate the names only.

Fix #13 

## Test

To test this pull request, you can run the following commands:

```shell
make test e2e-tests
```
