### PR TITLE
chore: bump version v0.1.7.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "environment-variable-policy"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "environment-variable-policy"
-version = "0.1.6"
-authors = ["José Guilherme Vanz <jvanz@jvanz.com>"]
+version = "0.1.7"
+authors = [
+	"José Guilherme Vanz <jvanz@jvanz.com>",
+	"Kubewarden Developers <cncf-kubewarden-maintainers@lists.cncf.io>"
+	]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.6
+version: 0.1.7
 name: environment-variable-policy
 displayName: Environment Variable Policy
-createdAt: 2023-10-16T08:43:19.959180861Z
+createdAt: 2024-06-13T21:14:11.314795321Z
 description: A Kubewarden Policy that controls the usage of environment variables
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/environment-variable-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.6
+  image: ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.7
 keywords:
 - deployment
 - replicaset
@@ -27,17 +27,17 @@ keywords:
 - environment-variables
 links:
 - name: policy
-  url: https://github.com/kubewarden/environment-variable-policy/releases/download/v0.1.6/policy.wasm
+  url: https://github.com/kubewarden/environment-variable-policy/releases/download/v0.1.7/policy.wasm
 - name: source
   url: https://github.com/kubewarden/environment-variable-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.6
+  kwctl pull ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.7
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.6
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/environment-variable-policy:v0.1.7
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and ArtifactHub files bumping the policy version to v0.1.7.

