### PR TITLE
Fix type of criteria variable

### DIFF
--- a/questions-ui.yml
+++ b/questions-ui.yml
@@ -5,6 +5,7 @@ questions:
     required: true
     label: "Criteria"
     variable: "criteria"
+    type: enum
     options:
       - "containsAnyOf"
       - "doesNotContainAnyOf"


### PR DESCRIPTION
By default variable type is `string`:

![Screenshot from 2025-06-23 15-12-21](https://github.com/user-attachments/assets/a919a561-84ae-417d-9dcd-c3607eaaf804)
