### PR TITLE
fix: Process cases when there's no env var block

### DIFF
--- a/e2e.bats
+++ b/e2e.bats
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
 
 @test "Test containsAnyOf" {
-	run kwctl run  --request-path test_data/deployment_containsAnyOf.json --settings-path test_data/settings_containsAnyOf.json  annotated-policy.wasm
+	run kwctl run --request-path test_data/deployment_containsAnyOf.json --settings-path test_data/settings_containsAnyOf.json annotated-policy.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
- }
+}
 
 @test "Test containsAnyOf against no env vars" {
 	run kwctl run --request-path test_data/deployment_no_envvars.json --settings-path test_data/settings_containsAnyOf.json annotated-policy.wasm
@@ -15,23 +15,22 @@
 }
 
 @test "Test doesNotContainAnyOf" {
-	run kwctl run  --request-path test_data/deployment_doesNotContainAnyOf.json --settings-path test_data/settings_doesNotContainAnyOf.json  annotated-policy.wasm
+	run kwctl run --request-path test_data/deployment_doesNotContainAnyOf.json --settings-path test_data/settings_doesNotContainAnyOf.json annotated-policy.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
- }
+}
 
 @test "Test containsAllOf" {
-	run kwctl run  --request-path test_data/deployment_containsAllOf.json --settings-path test_data/settings_containsAllOf.json  annotated-policy.wasm
+	run kwctl run --request-path test_data/deployment_containsAllOf.json --settings-path test_data/settings_containsAllOf.json annotated-policy.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
- }
+}
 
 @test "Test doesNotContainAllOf" {
-	run kwctl run  --request-path test_data/deployment_doesNotContainAllOf.json --settings-path test_data/settings_doesNotContainAllOf.json  annotated-policy.wasm
+	run kwctl run --request-path test_data/deployment_doesNotContainAllOf.json --settings-path test_data/settings_doesNotContainAllOf.json annotated-policy.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
- }
-
+}

--- a/e2e.bats
+++ b/e2e.bats
@@ -7,6 +7,13 @@
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
  }
 
+@test "Test containsAnyOf against no env vars" {
+	run kwctl run --request-path test_data/deployment_no_envvars.json --settings-path test_data/settings_containsAnyOf.json annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+}
+
 @test "Test doesNotContainAnyOf" {
 	run kwctl run  --request-path test_data/deployment_doesNotContainAnyOf.json --settings-path test_data/settings_doesNotContainAnyOf.json  annotated-policy.wasm
 	[ "$status" -eq 0 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,29 +33,31 @@ fn validate_envvar(settings: &Settings, env_vars: &[String]) -> Result<()> {
     }
 }
 
+// Returns a map with container names as keys and their environment variable names as values
 fn get_containers_env_vars(containers: &[Container]) -> HashMap<String, Vec<String>> {
     let mut results = HashMap::new();
     for container in containers {
-        let envvar_names = match &container.env {
-            Some(envvar) => envvar.iter().map(|e| e.name.clone()).collect(),
-            None => Vec::new(), // insert empty vector when no env vars are present, we should
-                                // evaluate this case too for containsAnyOf and containsAllOf
-        };
+        let envvar_names: Vec<String> = container
+            .env
+            .as_ref()
+            .map(|envvars| envvars.iter().map(|e| e.name.clone()).collect())
+            .unwrap_or_default();
         results.insert(container.name.clone(), envvar_names);
     }
     results
 }
 
+// Returns a map with ephemeral container names as keys and their environment variable names as values
 fn get_ephemeral_containers_env_vars(
     containers: &[EphemeralContainer],
 ) -> HashMap<String, Vec<String>> {
     let mut results = HashMap::new();
     for container in containers {
-        let envvar_names = match &container.env {
-            Some(envvar) => envvar.iter().map(|e| e.name.clone()).collect(),
-            None => Vec::new(), // insert empty vector when no env vars are present, we should
-                                // evaluate this case too for containsAnyOf and containsAllOf
-        };
+        let envvar_names: Vec<String> = container
+            .env
+            .as_ref()
+            .map(|envvars| envvars.iter().map(|e| e.name.clone()).collect())
+            .unwrap_or_default();
         results.insert(container.name.clone(), envvar_names);
     }
     results
@@ -106,51 +108,116 @@ mod tests {
 
     use crate::CONTAINS_ANY_OF_ERROR_MSG;
 
-    #[test]
-    fn test_envvar_extraction() {
-        let envvars = ["a".to_owned(), "c".to_owned()];
-        let container_envvar = Some(
-            envvars
-                .iter()
-                .map(|name| apicore::EnvVar {
-                    name: name.clone(),
-                    ..Default::default()
-                })
-                .collect::<Vec<_>>(),
-        );
+    use rstest::rstest;
 
-        let containers = vec![
+    #[rstest]
+    #[case(
+        vec![
             apicore::Container {
                 name: "test-container1".to_string(),
-                env: container_envvar.clone(),
+                env: Some(vec![
+                    apicore::EnvVar {
+                        name: "a".to_string(),
+                        ..Default::default()
+                    },
+                    apicore::EnvVar {
+                        name: "b".to_string(),
+                        ..Default::default()
+                    },
+                ]),
                 ..Default::default()
             },
             apicore::Container {
                 name: "test-container2".to_string(),
-                env: container_envvar.clone(),
+                env: Some(vec![
+                    apicore::EnvVar {
+                        name: "x".to_string(),
+                        ..Default::default()
+                    },
+                    apicore::EnvVar {
+                        name: "y".to_string(),
+                        ..Default::default()
+                    },
+                ]),
                 ..Default::default()
             },
-        ];
-        let ephemeral_containers = vec![
+        ],
+        HashMap::from([
+            ("test-container1".to_string(), vec!["a".to_owned(), "b".to_owned()]),
+            ("test-container2".to_string(), vec!["x".to_owned(), "y".to_owned()]),
+        ])
+    )]
+    #[case(
+        vec![
+            apicore::Container {
+                name: "test-container3".to_string(),
+                env: None,
+                ..Default::default()
+            },
+        ],
+        HashMap::from([("test-container3".to_string(), vec![])])
+    )]
+    fn test_get_containers_env_vars(
+        #[case] containers: Vec<apicore::Container>,
+        #[case] expected: HashMap<String, Vec<String>>,
+    ) {
+        let result = get_containers_env_vars(&containers);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(
+        vec![
             apicore::EphemeralContainer {
-                name: "test-container1".to_string(),
-                env: container_envvar.clone(),
+                name: "test-ephemeral1".to_string(),
+                env: Some(vec![
+                    apicore::EnvVar {
+                        name: "foo".to_owned(),
+                        ..Default::default()
+                    },
+                    apicore::EnvVar {
+                        name: "bar".to_owned(),
+                        ..Default::default()
+                    },
+                ]),
                 ..Default::default()
             },
             apicore::EphemeralContainer {
-                name: "test-container2".to_string(),
-                env: container_envvar.clone(),
+                name: "test-ephemeral2".to_string(),
+                env: Some(vec![
+                    apicore::EnvVar {
+                        name: "baz".to_owned(),
+                        ..Default::default()
+                    },
+                    apicore::EnvVar {
+                        name: "qux".to_owned(),
+                        ..Default::default()
+                    },
+                ]),
                 ..Default::default()
             },
-        ];
-        let mut result = get_containers_env_vars(&containers);
-        assert_eq!(result.get("test-container1").unwrap(), &envvars.to_vec());
-        assert_eq!(result.get("test-container2").unwrap(), &envvars.to_vec());
-        assert_eq!(result.len(), 2);
-        result = get_ephemeral_containers_env_vars(&ephemeral_containers);
-        assert_eq!(result.get("test-container1").unwrap(), &envvars.to_vec());
-        assert_eq!(result.get("test-container2").unwrap(), &envvars.to_vec());
-        assert_eq!(result.len(), 2);
+        ],
+        HashMap::from([
+            ("test-ephemeral1".to_string(), vec!["foo".to_owned(), "bar".to_owned()]),
+            ("test-ephemeral2".to_string(), vec!["baz".to_owned(), "qux".to_owned()]),
+        ])
+    )]
+    #[case(
+        vec![
+            apicore::EphemeralContainer {
+                name: "test-ephemeral3".to_string(),
+                env: None,
+                ..Default::default()
+            },
+        ],
+        HashMap::from([("test-ephemeral3".to_string(), vec![])])
+    )]
+    fn test_get_ephemeral_containers_env_vars(
+        #[case] ephemeral_containers: Vec<apicore::EphemeralContainer>,
+        #[case] expected: HashMap<String, Vec<String>>,
+    ) {
+        let result = get_ephemeral_containers_env_vars(&ephemeral_containers);
+        assert_eq!(result, expected);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,12 @@ fn validate_envvar(settings: &Settings, env_vars: &[String]) -> Result<()> {
 fn get_containers_env_vars(containers: &[Container]) -> HashMap<String, Vec<String>> {
     let mut results = HashMap::new();
     for container in containers {
-        if let Some(envvar) = &container.env {
-            results.insert(
-                container.name.clone(),
-                envvar.iter().map(|e| e.name.clone()).collect(),
-            );
-        }
+        let envvar_names = match &container.env {
+            Some(envvar) => envvar.iter().map(|e| e.name.clone()).collect(),
+            None => Vec::new(), // insert empty vector when no env vars are present, we should
+                                // evaluate this case too for containsAnyOf and containsAllOf
+        };
+        results.insert(container.name.clone(), envvar_names);
     }
     results
 }
@@ -51,12 +51,12 @@ fn get_ephemeral_containers_env_vars(
 ) -> HashMap<String, Vec<String>> {
     let mut results = HashMap::new();
     for container in containers {
-        if let Some(envvar) = &container.env {
-            results.insert(
-                container.name.clone(),
-                envvar.iter().map(|e| e.name.clone()).collect(),
-            );
-        }
+        let envvar_names = match &container.env {
+            Some(envvar) => envvar.iter().map(|e| e.name.clone()).collect(),
+            None => Vec::new(), // insert empty vector when no env vars are present, we should
+                                // evaluate this case too for containsAnyOf and containsAllOf
+        };
+        results.insert(container.name.clone(), envvar_names);
     }
     results
 }

--- a/test_data/deployment_no_envvars.json
+++ b/test_data/deployment_no_envvars.json
@@ -1,0 +1,165 @@
+{
+  "dryRun": false,
+  "kind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "name": "nginx",
+  "namespace": "default",
+  "object": {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "annotations": {
+        "io.kubewarden.policy.echo.create": "true"
+      },
+      "creationTimestamp": "2022-09-26T14:27:34Z",
+      "generation": 1,
+      "managedFields": [
+        {
+          "apiVersion": "apps/v1",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:io.kubewarden.policy.echo.create": {},
+                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+              }
+            },
+            "f:spec": {
+              "f:progressDeadlineSeconds": {},
+              "f:replicas": {},
+              "f:revisionHistoryLimit": {},
+              "f:selector": {},
+              "f:strategy": {
+                "f:rollingUpdate": {
+                  ".": {},
+                  "f:maxSurge": {},
+                  "f:maxUnavailable": {}
+                },
+                "f:type": {}
+              },
+              "f:template": {
+                "f:metadata": {
+                  "f:labels": {
+                    ".": {},
+                    "f:app": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"nginx\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            }
+          },
+          "manager": "kubectl-client-side-apply",
+          "operation": "Update",
+          "time": "2022-09-26T14:27:34Z"
+        }
+      ],
+      "name": "nginx",
+      "namespace": "default",
+      "uid": "1ddc267a-538f-4718-814e-94e04cc7397e"
+    },
+    "spec": {
+      "progressDeadlineSeconds": 600,
+      "replicas": 0,
+      "revisionHistoryLimit": 10,
+      "selector": {
+        "matchLabels": {
+          "app": "nginx"
+        }
+      },
+      "strategy": {
+        "rollingUpdate": {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%"
+        },
+        "type": "RollingUpdate"
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "app": "nginx"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "image": "nginx:latest",
+              "imagePullPolicy": "Always",
+              "name": "nginx",
+              "ports": [
+                {
+                  "containerPort": 80,
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  "operation": "CREATE",
+  "options": {
+    "apiVersion": "meta.k8s.io/v1",
+    "fieldManager": "kubectl-client-side-apply",
+    "kind": "CreateOptions"
+  },
+  "requestKind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "requestResource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "resource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "uid": "82d340c2-6082-498b-acec-93ec7a2377df",
+  "userInfo": {
+    "groups": ["system:masters", "system:authenticated"],
+    "username": "system:admin"
+  }
+}


### PR DESCRIPTION
## Description

If there's no env var block, since we are validating in
`validate_environment_variables()` by iterating through all the envvar
sets, we will skip all validation and wrongly accept the request.

To fix this, when extracting env var sets from containers and init
containers, add empty env var sets to the `envvars` Hashmap that reflect
that indeed there were no envvars.

This wasn't caught in the past as the unit tests correctly contain empty
sets that are correctly evaluated by our functions, but those empty sets
were never created and passed to the functions.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added new e2e with a container that has no env block. 
The test should correctly reject for containsAnyOf.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

To be released via PR automation as 2.0.3.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
