### PR TITLE
Update questions-ui for version 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ trade-offs:
 
 ## Settings
 
-> [!WARNING]  
+> [!WARNING]
 > If you are upgrading from version v1.x.x, please note the breaking changes
 > introduced in v2.x.x:
 >
@@ -62,11 +62,13 @@ The `criteria` configuration can have the following values:
   are defined in the resource.
 - `doesNotContainAllOf`: enforces that the environment variables in `values`
   are not all set together in the resource. It's the opposite of `containsAllOf`.
+- `ContainsOtherThan`
+- `DoesNotContainOtherThan`
 
 The `values` field must contain at least one environment variable name for
 validation. Environment variable names should follow the C_IDENTIFIER standard.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > An empty list of environment variable names is not allowed.
 
 If you require more complex environment variable validation, consider the use

--- a/questions-ui.yml
+++ b/questions-ui.yml
@@ -17,6 +17,6 @@ questions:
     label: "Environment variables"
     description: "Environment variables names to be validated with the resources definition"
     group: Settings
-    variable: envvars
+    variable: values
     required: true
     type: array[


### PR DESCRIPTION
## Description

Policy questions use v1 variable name `envvars` but policy expects `values` as described in README.

```bash
~ k logs -n cattle-kubewarden-system policy-server-default-65b5954cd5-bfc5p
Error: Policy settings are invalid: Error invoking settings validation callback: GuestCallFailure("Error decoding validation payload {\"criteria\":\"containsAnyOf\",\"envvars\":[\"fsd\"]}: Error(\"missing field `values`\", line: 0, column: 0)")
```

<img width="1883" height="949" alt="Screenshot From 2025-08-12 09-36-09" src="https://github.com/user-attachments/assets/d704b1f6-936e-41c0-8b9c-1ad38421f283" />
